### PR TITLE
Deploy to github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+---
+
+name: CI
+on: [push, pull_request]
+
+jobs:
+  mdbook:
+    uses: ferrous-systems/shared-github-actions/.github/workflows/mdbook-to-github-pages.yml@main
+    with:
+      cname: espressif-trainings.ferrous-systems.com
+      path: book/


### PR DESCRIPTION
This configures GitHub Actions to publish the book on `espressif-trainings.ferrous-systems.com`. This will require GitHub pages to be enabled in the settings after the PR is merged.