### PR TITLE
Removed double queue in text

### DIFF
--- a/advanced/button-interrupt/exercise/src/main.rs
+++ b/advanced/button-interrupt/exercise/src/main.rs
@@ -6,18 +6,17 @@ use std::ptr;
 use esp_idf_sys::{
     self as _, c_types::c_void, esp, gpio_config, gpio_config_t, gpio_install_isr_service,
     gpio_int_type_t_GPIO_INTR_POSEDGE, gpio_isr_handler_add, gpio_mode_t_GPIO_MODE_INPUT,
-    xQueueGenericCreate, xQueueGiveFromISR, xQueueReceive, QueueHandle_t,ESP_INTR_FLAG_IRAM,
+    xQueueGenericCreate, xQueueGiveFromISR, xQueueReceive, QueueHandle_t, ESP_INTR_FLAG_IRAM,
 };
 
-// 4. Create a `static mut` that holds the queue handle.
+// 5. Create a `static mut` that holds the queue handle.
 static mut EVENT_QUEUE: Option<QueueHandle_t> = None;
 
-// 6. Define what the interrupt handler does, once the button is pushed. Button_interrupt sends a message into the queue. 
+// 6. Define what the interrupt handler does, once the button is pushed. Button_interrupt sends a message into the queue.
 #[link_section = ".iram0.text"]
 unsafe extern "C" fn button_interrupt(_: *mut c_void) {
     xQueueGiveFromISR(EVENT_QUEUE.unwrap(), std::ptr::null_mut());
 }
-
 
 fn main() -> anyhow::Result<()> {
     const GPIO_NUM: i32 = 9;
@@ -28,23 +27,20 @@ fn main() -> anyhow::Result<()> {
     // };
 
     unsafe {
-
         // 2. write the GPIO configuration into the register
         // esp!(...)?;
 
-
-        // 3. Install the global GPIO interrupt handler
+        // 3. write the global GPIO interrupt handler
         // esp!(...)?;
 
         // Queue configurations
         const QUEUE_TYPE_BASE: u8 = 0;
-        const ITEM_SIZE: u32 = 0; 
+        const ITEM_SIZE: u32 = 0;
         const QUEUE_SIZE: u32 = 1;
 
-        // 5. Create an event queue
+        // 4. Create an event queue
         // EVENT_QUEUE = Some(...);
-        
-        
+
         // 7. Add the button GPIO and the function to the interrupt handler
         // esp!(...)?;
     }
@@ -57,12 +53,8 @@ fn main() -> anyhow::Result<()> {
 
             // 8. Receive the event from the queue.
             // let res = ...;
-            
-            // If the event has the value 0, nothing happens. if it has a different value, the button was pressed. 
-            match res {
-                1 => println!("button pressed!"),
-                _ => {},
-            };
+
+            // 9. If the event has the value 0, nothing happens. if it has a different value, the button was pressed.
         }
     }
 }

--- a/book/src/04_4_interrupts.md
+++ b/book/src/04_4_interrupts.md
@@ -11,32 +11,36 @@ TODO why are some functions called with some(...), esp!(...) or "normal"?
 
 ## Tasks
 
-1. Configure the button (GPIO 9) with a c struct [`gpio_config_t`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/struct.gpio_config_t.html)the following settings:
+✅ Configure the button GPIO 9 with a c struct [`gpio_config_t`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/struct.gpio_config_t.html)the following settings (1. in the exercise/src/main.rs):
     - input mode
     - pull up
     - interrupt on positive edge
   
-  TODO add the variable names for the settings
+    
+    
+### Hints!
 
-2. Write the configuration into the register with [`unsafe extern "C" fn gpio_config`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/fn.gpio_config.html). This needs to happen in the unsafe block. To make these FFI calls we can use the macro `esp!($Cfunktion)`.
+- Use bit shift to set a `1` in the right position with the constant GPIO_NUM.
+- The fields `pull_up_en` and `pull_down_en` can be set with `true/false.into()`, or just `0/1`.
+- The other two constants you need to set to true have been imported by `esp_idf_sys`, so use those or just 1. 
+
+✅  Write the configuration into the register with [`unsafe extern "C" fn gpio_config`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/fn.gpio_config.html) (2. in the exercise/src/main.rs). This needs to happen in the unsafe block. To make these FFI calls we can use the macro `esp!($Cfunktion)`.
 
 
-3. Install a generic GPIO interrupt handler with [`unsafe extern "C" fn gpio_install_isr_service`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/fn.gpio_install_isr_service.html). This function takes `ESP_INTR_FLAG_IRAM` as argument.
+✅  Write a generic GPIO interrupt handler with [`unsafe extern "C" fn gpio_install_isr_service`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/fn.gpio_install_isr_service.html) (3. in the exercise/src/main.rs). This function takes `ESP_INTR_FLAG_IRAM` as argument (imported by `esp_idf_sys`).
 
 
-4. Create a `static mut` that holds the queue handle we are going to get from `xQueueGenericCreate`. This is a number that uniquely identifies one particular queue, as opposed to any of the other queues in our program. The queue storage itself if managed by the Operating System.
-
-```rust
-static mut EVENT_QUEUE: Option<QueueHandle_t> = None;
-```
-
-5. Create the event queue using [`pub unsafe extern "C" fn xQueueGenericCreate`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/fn.xQueueGenericCreate.html). This lets us safely pass events from an interrupt routine to our main thread.
+✅  Create the event queue using [`pub unsafe extern "C" fn xQueueGenericCreate`](https://esp-rs.github.io/esp-idf-sys/esp_idf_sys/fn.xQueueGenericCreate.html) (4. in the exercise/src/main.rs). This lets us safely pass events from an interrupt routine to our main thread.
 
 ```rust
 EVENT_QUEUE = Some(xQueueGenericCreate(QUEUE_SIZE, ITEM_SIZE, QUEUE_TYPE_BASE));
 ```
 
-6. Add a function which that will be called whenever there is a GPIO interrupt on our button pin. We put this function in a special block of RAM (`iram0`), so it will still be available even if the external flash is busy doing something else (like filesystem work). The function needs to get the queue handle from `EVENT_QUEUE` and call the `xQueueGiveFromISR` function with a `std::ptr::null_mut()` - the objects in our queue are of size zero, so we don't actually need a 'thing' to put on the queue. Instead, the act of pushing a 'nothing' is enough to wake up the other end!
+
+🔎  The `static mut EVENT_QUEUE: Option<QueueHandle_t> = None` (5. in the exercise/src/main.rs) holds the queue handle we are going to get from `xQueueGenericCreate`. This is a number that uniquely identifies one particular queue, as opposed to any of the other queues in our program. The queue storage itself if managed by the Operating System. This variable is declared on line 13.
+
+
+Look at the function that will be called whenever there is a GPIO interrupt on our button pin (6. in the exercise/src/main.rs). We put this function in a special block of RAM (`iram0`), so it will still be available even if the external flash is busy doing something else (like filesystem work). The function needs to get the queue handle from `EVENT_QUEUE` and call the `xQueueGiveFromISR` function with a `std::ptr::null_mut()` - the objects in our queue are of size zero, so we don't actually need a 'thing' to put on the queue. Instead, the act of pushing a 'nothing' is enough to wake up the other end!
 
 ```rust
 #[link_section = ".iram0.text"]
@@ -49,7 +53,7 @@ TODO Add explanation
     - what is added to the queue
     - why is it in RAM
 
-7. Pass the function we just wrote to the generic GPIO interrupt handler we registered earlier, along with the number of the GPIO pin that should cause this function to be executed.
+✅ Pass the function `button_interrupt` (6.) to the generic GPIO interrupt handler (7. in the exercise/src/main.rs) we registered earlier, along with the number of the GPIO pin that should cause this function to be executed.
 
 ```rust
 esp!(gpio_isr_handler_add(
@@ -59,15 +63,12 @@ esp!(gpio_isr_handler_add(
 ))?;
 ```
 
-8. Inside a loop, wait until the queue has an item in it. That is, until the `button_interrupt` function puts something in the queue.
+✅  Inside a loop, wait until the queue has an item in it (8. in the exercise/src/main.rs). That is, until the `button_interrupt` function puts something in the queue.
 
 ```rust
 let res = xQueueReceive(EVENT_QUEUE.unwrap(), ptr::null_mut(), QUEUE_WAIT_TICKS);
 ```
+✅  Match the `res` with a `println!()` to the screen indicating the button was pushed. (9. in the exercise/src/main.rs).
 
-
-## Modify
-
-TODO
 
 


### PR DESCRIPTION
Removed double creating queue, redid numerotation so it match the example code.
