### PR TITLE
Add `ignore` dependency

### DIFF
--- a/advanced/i2c-driver/Cargo.toml
+++ b/advanced/i2c-driver/Cargo.toml
@@ -21,7 +21,7 @@ esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
 esp-idf-hal = "=0.38"
 anyhow = "1"
 embedded-hal = "0.2.7"
-
+ignore = "=0.4.11"
 
 [build-dependencies]
 embuild = "0.28"

--- a/advanced/i2c-sensor-reading/Cargo.toml
+++ b/advanced/i2c-sensor-reading/Cargo.toml
@@ -25,8 +25,7 @@ shtcx = "0.10.0"
 lis3dh = "0.4.1"
 shared-bus = "0.2.4"
 icm42670p = { path = "../../common/lib/icm42670p" }
-
-
+ignore = "=0.4.11"
 
 [build-dependencies]
 embuild = "0.28"

--- a/common/lib/esp32-c3-dkc02-bsc/Cargo.lock
+++ b/common/lib/esp32-c3-dkc02-bsc/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -210,9 +216,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
 dependencies = [
  "bare-metal 1.0.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cortex-m",
  "riscv 0.7.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -221,8 +237,8 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.6",
 ]
 
 [[package]]
@@ -231,9 +247,9 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.6",
 ]
 
 [[package]]
@@ -243,11 +259,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.6",
  "memoffset",
  "once_cell",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -256,7 +283,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -534,6 +561,7 @@ dependencies = [
  "esp-idf-svc",
  "esp-idf-sys",
  "esp32c3",
+ "ignore",
  "log",
  "rgb",
  "riscv 0.8.0",
@@ -566,7 +594,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "windows-sys",
@@ -649,7 +677,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
@@ -753,11 +781,11 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
-version = "0.4.18"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+checksum = "522daefc3b69036f80c7d2990b28ff9e0471c683bad05ca258e0a01dd22c5a1e"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-channel 0.4.4",
  "globset",
  "lazy_static",
  "log",
@@ -775,7 +803,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -808,7 +836,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -827,8 +855,14 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -993,9 +1027,9 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.5.5",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.6",
  "num_cpus",
 ]
 
@@ -1304,7 +1338,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",

--- a/common/lib/esp32-c3-dkc02-bsc/Cargo.toml
+++ b/common/lib/esp32-c3-dkc02-bsc/Cargo.toml
@@ -17,3 +17,4 @@ log = "0.4"
 anyhow = "1"
 toml-cfg = "0.1"
 riscv = { version = "0.8" }
+ignore = "=0.4.11"

--- a/intro/hardware-check/Cargo.toml
+++ b/intro/hardware-check/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 opt-level = "s"
 
 [profile.dev]
-debug = true # Symbols are nice and they don't increase the size on Flash
+debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [features]
@@ -18,11 +18,12 @@ native = ["esp-idf-sys/native"]
 
 [dependencies]
 esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
-esp-idf-svc = { version="=0.41.4", features = ["experimental", "alloc"] }
+esp-idf-svc = { version = "=0.41.4", features = ["experimental", "alloc"] }
 esp32-c3-dkc02-bsc = { path = "../../common/lib/esp32-c3-dkc02-bsc" }
 log = "0.4"
 anyhow = "1"
 toml-cfg = "0.1"
+ignore = "=0.4.11"
 
 [build-dependencies]
 embuild = "0.28"

--- a/intro/http-client/Cargo.toml
+++ b/intro/http-client/Cargo.toml
@@ -23,6 +23,7 @@ esp32-c3-dkc02-bsc = { path = "../../common/lib/esp32-c3-dkc02-bsc" }
 embedded-svc = "=0.21"
 anyhow = "1.0"
 toml-cfg = "0.1"
+ignore = "=0.4.11"
 
 [build-dependencies]
 embuild = "0.28"

--- a/intro/http-server/Cargo.toml
+++ b/intro/http-server/Cargo.toml
@@ -24,6 +24,7 @@ esp32c3 = "=0.4"
 embedded-svc = "=0.21"
 anyhow = "1.0"
 toml-cfg = "0.1"
+ignore = "=0.4.11"
 
 [build-dependencies]
 embuild = "0.28"

--- a/intro/mqtt/exercise/Cargo.toml
+++ b/intro/mqtt/exercise/Cargo.toml
@@ -28,6 +28,7 @@ esp32c3 = "=0.4"
 riscv = { version = "0.8" }
 get-uuid = { path = "../../../common/lib/get-uuid" }
 mqtt-messages = { path = "../../../common/lib/mqtt-messages" }
+ignore = "=0.4.11"
 
 [build-dependencies]
 embuild = "0.28"


### PR DESCRIPTION
As seen in #127, some of the examples were not building. As [suggested per @ashnikel](https://github.com/ferrous-systems/espressif-trainings/issues/127#issuecomment-1385523705) adding this dependency solves the issue.

Closes #127 