### PR TITLE
Add https example CI check

### DIFF
--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -22,10 +22,6 @@ fi
 
 if [[ "$1" == intro/http-client ]]; then
     $HOME/.cargo/bin/cargo build --example http_client
-    # HTTPS Client example requires updating sdkconfig.defaults before buidling
-    sed -i 's/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y/g' sdkconfig.defaults
-    sed -i 's/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=n/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y/g' sdkconfig.defaults
-    $HOME/.cargo/bin/cargo clean
     $HOME/.cargo/bin/cargo build --example https_client
 fi
 

--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -22,8 +22,11 @@ fi
 
 if [[ "$1" == intro/http-client ]]; then
     $HOME/.cargo/bin/cargo build --example http_client
-    # TODO: Update sdkconfig.defaults before buidling
-    # $HOME/.cargo/bin/cargo build --example https_client
+    # HTTPS Client example requires updating sdkconfig.defaults before buidling
+    sed -i 's/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y/g' sdkconfig.defaults
+    sed -i 's/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=n/CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y/g' sdkconfig.defaults
+    $HOME/.cargo/bin/cargo clean
+    $HOME/.cargo/bin/cargo build --example https_client
 fi
 
 if [[ "$1" == intro/http-server ]]; then

--- a/advanced/button-interrupt/sdkconfig.defaults
+++ b/advanced/button-interrupt/sdkconfig.defaults
@@ -1,10 +1,6 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
 
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
-
 # TODO this does not seem to work (should enable log level DEBUG)
 CONFIG_LOG_DEFAULT_LEVEL_INFO=n
 CONFIG_LOG_DEFAULT_LEVEL=4

--- a/book/src/03_3_3_https_client.md
+++ b/book/src/03_3_3_https_client.md
@@ -9,16 +9,7 @@ You will now make changes to your http client files so that it also works for en
 cargo espflash --release --example https_client --monitor $SERIALDEVICE
 ```
 
-To establish a secure, encrypted HTTPS connection, we first need to add some certificates so a server's identity can be verified.
-
-✅ Enable basic TLS certificate support in your project's `sdkconfig.defaults` by deleting the existing `CONFIG_MBEDTLS...` lines and adding:
-
-```cfg
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=y
-```
-
-Now, we create a custom client configuration to use an `http::client::EspHttpClientConfiguration` which enables the use of these certificates and uses default values for everything else:
+Create a custom client configuration to use an `http::client::EspHttpClientConfiguration` which enables the use of these certificates and uses default values for everything else:
 
 ```rust
 let mut client = EspHttpClient::new(&EspHttpClientConfiguration {
@@ -33,7 +24,7 @@ let mut client = EspHttpClient::new(&EspHttpClientConfiguration {
 
 ## Troubleshooting (repeated from previous section)
 
-- `missing WiFi name/password`: ensure that you've configured `cfg.toml` according to `cfg.toml.example` - a common problem is that package name and config section name don't match. 
+- `missing WiFi name/password`: ensure that you've configured `cfg.toml` according to `cfg.toml.example` - a common problem is that package name and config section name don't match.
 
 ```toml
 # Cargo.toml

--- a/intro/hardware-check/sdkconfig.defaults
+++ b/intro/hardware-check/sdkconfig.defaults
@@ -1,6 +1,2 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
-
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/intro/http-client/examples/https_client.rs
+++ b/intro/http-client/examples/https_client.rs
@@ -37,7 +37,6 @@ fn get(url: impl AsRef<str>) -> anyhow::Result<()> {
     // 1. create a new EspHttpClient with SSL certificates enabled
     let mut client = EspHttpClient::new(&EspHttpClientConfiguration {
         use_global_ca_store: true,
-        // TODO: Fix this
         crt_bundle_attach: Some(esp_idf_sys::esp_crt_bundle_attach),
 
         ..Default::default()

--- a/intro/http-client/sdkconfig.defaults
+++ b/intro/http-client/sdkconfig.defaults
@@ -1,5 +1,2 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
-
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN=n

--- a/intro/http-server/sdkconfig.defaults
+++ b/intro/http-server/sdkconfig.defaults
@@ -1,6 +1,2 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
-
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n

--- a/intro/mqtt/exercise/sdkconfig.defaults
+++ b/intro/mqtt/exercise/sdkconfig.defaults
@@ -1,10 +1,6 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
 
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
-
 # TODO this does not seem to work (should enable log level DEBUG)
 CONFIG_LOG_DEFAULT_LEVEL_INFO=n
 CONFIG_LOG_DEFAULT_LEVEL=4


### PR DESCRIPTION
- ~~CI now updates `sdkconfig.defaults` before building HTTPS client example~~
- Removed the todo in `https_client.rs` all it needed is a `cargo clean`
- Removed certificate config from all `sdkconfig.defaults`
  - https://github.com/espressif/esp-idf/issues/7631