### PR TITLE
Fix subst command in book

### DIFF
--- a/book/src/02_3_repository.md
+++ b/book/src/02_3_repository.md
@@ -13,7 +13,7 @@ cd espressif-trainings
 
 ```console
 git clone https://github.com/esp-rs/espressif-trainings.git
-subst r:\ espressif-trainings
+subst r: espressif-trainings
 cd r:\
 ```
 


### PR DESCRIPTION
While following the instructions in the book I noticed that the command to substitute the path on Windows results in an error: 

```
subst r:\ espressif-trainings
Invalid parameter - R:\
```

This PR removes the `\` in the command to make it work. Please also refer to the [Microsoft docs for subst](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/subst). 