### PR TITLE
Update runner command to remove `flash`.

### DIFF
--- a/advanced/button-interrupt/.cargo/config.toml
+++ b/advanced/button-interrupt/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]

--- a/advanced/i2c-driver/.cargo/config.toml
+++ b/advanced/i2c-driver/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]

--- a/advanced/i2c-sensor-reading/.cargo/config.toml
+++ b/advanced/i2c-sensor-reading/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]

--- a/intro/hardware-check/.cargo/config.toml
+++ b/intro/hardware-check/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]

--- a/intro/http-client/.cargo/config.toml
+++ b/intro/http-client/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]

--- a/intro/http-server/.cargo/config.toml
+++ b/intro/http-server/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]

--- a/intro/mqtt/exercise/.cargo/config.toml
+++ b/intro/mqtt/exercise/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "riscv32imc-esp-espidf"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16
 rustflags = ["-C", "default-linker-libraries"]


### PR DESCRIPTION
With the `flash` sub-command, the following error is produced.
```
     Running `espflash flash --monitor target/riscv32imc-esp-espidf/debug/hardware-check`
New version of espflash is available: v2.0.0-rc.3

Error: espflash::connection_failed

  × Error while connecting to device
  ╰─▶ Serial port not found
  help: Ensure that the device is connected and your host recognizes the serial adapter

```

This updates all of the `.cargo/config.toml` files to remove the `flash` sub-command. This make's it work on macOS and Linux without the error.

Closes: https://github.com/esp-rs/espressif-trainings/issues/182