### PR TITLE
fix typo

### DIFF
--- a/book/src/03_5_3_mqtt.md
+++ b/book/src/03_5_3_mqtt.md
@@ -17,8 +17,8 @@ cargo run --example solution_publ_rcv
 ### Encoding and decoding message payloads
 
 The board LED commands are made of three bytes indicating red, green, and blue.
-    - `enum ColorData` contains a topic `color_topic(uuid)` and the `BoardLed`
-    - It can convert the `data()` field of an `EspMqttMessage` by using `try_from()`. The message needs first to be coerced into a slice, using `let message_data: &[u8] = &message.data();`
+- `enum ColorData` contains a topic `color_topic(uuid)` and the `BoardLed`
+- It can convert the `data()` field of an `EspMqttMessage` by using `try_from()`. The message needs first to be coerced into a slice, using `let message_data: &[u8] = &message.data();`
 
 
 ```rust


### PR DESCRIPTION
Seems like there are some redundant spaces here. This is what the text originally looked like:

![1](https://github.com/esp-rs/espressif-trainings/assets/53737377/d7ce7949-d4e0-4c8c-95ef-57d00efe7b90)

After removing the spaces it looks like (becomes a list):

![2](https://github.com/esp-rs/espressif-trainings/assets/53737377/d4afb6b0-c470-4c7a-a338-075fd4ad0726)
