### PR TITLE
docs: update docs.esp-rs.org link to learn.microsoft.com

### DIFF
--- a/book/src/02_3_repository.md
+++ b/book/src/02_3_repository.md
@@ -11,7 +11,7 @@ cd std-training
 
 ❗ Windows users may have problems with [long path names][windows-long-path].
 
-[windows-long-path]: https://docs.esp-rs.org/book/troubleshooting/index.html#long-path-names
+[windows-long-path]: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
 
 ## Repository Contents
 


### PR DESCRIPTION
The `docs.esp-rs.org` domain has expired and now points to unsafe content.
This PR replaces the broken `windows-long-path` reference in the repository setup chapter.

The original target (`/book/troubleshooting/index.html#long-path-names`) does not exist in the new docs structure, so this PR points to the official Microsoft docs on Windows long-path limits, which is the underlying issue the surrounding text is calling out.

The replacement URL was verified to resolve (HTTP 200, follows redirects) before this PR was opened.

_Auto-generated as part of a coordinated link cleanup across `esp-rs`._